### PR TITLE
fix fail to create the directory when the log directory does not exist

### DIFF
--- a/lib/logger.py
+++ b/lib/logger.py
@@ -22,9 +22,10 @@ class Log(object):
                 handler = logging.handlers.TimedRotatingFileHandler(self.filepath, 'midnight', 1, 10, 'UTF-8')
             except IOError:
                 # check if log directory exists
-                if not os.path.exists(path):
+                parent_path = parent_path = os.path.abspath(os.path.dirname(self.filepath))
+                if not os.path.exists(parent_path):
                     # try to create the logs directory
-                    os.makedirs(path, mode=0755)
+                    os.makedirs(parent_path, mode=0755)
                 # and try again
                 handler = logging.handlers.TimedRotatingFileHandler(self.filepath, 'midnight', 1, 10, 'UTF-8')
 


### PR DESCRIPTION
pathという存在しない変数をos.makedirsに渡していたので、ログファイルを置くディレクトリのパスが渡るようにしました。
