### PR TITLE
Allow config files from outside of decanter directory

### DIFF
--- a/decanter/decanter.py
+++ b/decanter/decanter.py
@@ -154,8 +154,9 @@ def parse_args(filepath=__file__, source=sys.argv, custom_commands=[]):
     # 'type=argparse.FileType()' will confirm the existence of a file.
     # but it open file.
     args.config.close()
-    args.config = os.path.relpath(os.path.realpath(args.config.name),
-                                  os.path.dirname(os.path.realpath(filepath)))
+    config_path = os.path.realpath(args.config.name)
+    sys.path.append(os.path.dirname(config_path))
+    args.config = os.path.basename(config_path)
 
     return args
 

--- a/tests/parse_args/tests.py
+++ b/tests/parse_args/tests.py
@@ -35,7 +35,7 @@ class Tests(unittest.TestCase):
         args = shlex.split('decanter -c setup.py \
 -h example.com -p 8000 start')
         result = decanter.parse_args(source=args)
-        self.assertEqual(result.config, '../setup.py')
+        self.assertEqual(result.config, 'setup.py')
         self.assertEqual(result.hostname, 'example.com')
         self.assertEqual(result.port, 8000)
         self.assertEqual(result.command, 'start')
@@ -67,7 +67,7 @@ class Tests(unittest.TestCase):
         args = shlex.split('decanter --config setup.py \
 --hostname example.com --port 8000 start')
         result = decanter.parse_args(source=args)
-        self.assertEqual(result.config, '../setup.py')
+        self.assertEqual(result.config, 'setup.py')
         self.assertEqual(result.hostname, 'example.com')
         self.assertEqual(result.port, 8000)
         self.assertEqual(result.command, 'start')
@@ -99,7 +99,7 @@ class Tests(unittest.TestCase):
         args = shlex.split('decanter -c setup.py \
 --hostname example.com -p 8000 start')
         result = decanter.parse_args(source=args)
-        self.assertEqual(result.config, '../setup.py')
+        self.assertEqual(result.config, 'setup.py')
         self.assertEqual(result.hostname, 'example.com')
         self.assertEqual(result.port, 8000)
         self.assertEqual(result.command, 'start')


### PR DESCRIPTION
This is to handle the use case in which the 'app' directory is outside the decanter directory, and therefore the config file is not in the decanter directory hierarchy.
