### PR TITLE
fix session writing

### DIFF
--- a/decanter/lib/middleware.py
+++ b/decanter/lib/middleware.py
@@ -119,6 +119,4 @@ class SessionWsgi(object):
         ses = Session(ExpressSession(sc))
         ses.read()
         environ['express.session'] = ses
-        res = self.app(environ, start_response)
-        ses.write()
-        return res
+        return self.app(environ, start_response)

--- a/decanter/lib/plugin.py
+++ b/decanter/lib/plugin.py
@@ -2,10 +2,11 @@
 # -*- coding: utf-8 -*-
 
 import os
-import json
-import traceback
-import gettext
 import re
+import json
+import gettext
+import traceback
+from bottle import request
 from functools import wraps
 from jinja2 import BaseLoader
 from jinja2 import Environment
@@ -287,6 +288,31 @@ class JsonPlugin(object):
             response.set_header('Content-Type', 'application/json')
             return json.dumps(data)
 
+        return wrapper
+
+    def setup(self, app):
+        pass
+
+    def close(self):
+        pass
+
+
+class SessionPlugin(object):
+    name = 'session'
+    api = 2
+
+    def __init__(self):
+        pass
+
+    def apply(self, callback, route):
+        @wraps(callback)
+        def wrapper(*args, **kwargs):
+            if self.name in route.skiplist:
+                return callback(*args, **kwargs)
+            data = callback(*args, **kwargs)
+            if 'express.session' in request.environ:
+                request.environ['express.session'].write()
+            return data
         return wrapper
 
     def setup(self, app):


### PR DESCRIPTION
After a wsgi wrapper returns the response is already been written and nothing else can be set. So that is why cookies or any other header cannot be set at that stage.
The solution is to write the cookie before the wsgi returns which means i had to reintroduce the SessionPlugin so that after the controller action is executed we can write the session.

So the session is initialize as soon as we get a request (in the middleware) and is written after each controller action is executed (in the plugin).
