### PR TITLE
Create timeout plugin

### DIFF
--- a/decanter/app/bundles/home/controllers/index.py
+++ b/decanter/app/bundles/home/controllers/index.py
@@ -10,6 +10,6 @@ def index():
 
 
 @get('/home/')
-@get('/home/<name>')
+@get('/home/<name>', timeout=30)
 def home(name='Decanter'):
     return {'greeting': "Hello {0}!".format(name.title())}

--- a/decanter/app/config/settings.py
+++ b/decanter/app/config/settings.py
@@ -47,7 +47,10 @@ default = {
 }
 
 # list of plugins names to install by default
-plugins = ['jinja2']
+plugins = ['timeout', 'jinja2']
+
+# default timeout seconds
+timeout = 60
 
 # redis config settings
 redis = {


### PR DESCRIPTION
This plugin manage timeout. Default timeout is 60 seconds.
If happen timeout, decanter return the http status code 503.

You can override that time by app/config/settings.py .
settings.py:
`timeout = 30`

Furthermore, you can override each function of controller by decorator.
@get('/home/<name>', timeout=30)
